### PR TITLE
fix for SymfonyHandler

### DIFF
--- a/lib/Handler/SymfonyConsoleHandler.php
+++ b/lib/Handler/SymfonyConsoleHandler.php
@@ -11,24 +11,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 class SymfonyConsoleHandler extends AbstractHandler
 {
     private $outputInterface = null;
-    private $verbosityLevelMap = array(
-        LogLevel::EMERGENCY => OutputInterface::VERBOSITY_NORMAL,
-        LogLevel::ALERT => OutputInterface::VERBOSITY_NORMAL,
-        LogLevel::CRITICAL => OutputInterface::VERBOSITY_NORMAL,
-        LogLevel::ERROR => OutputInterface::VERBOSITY_NORMAL,
-        LogLevel::WARNING => OutputInterface::VERBOSITY_NORMAL,
-        LogLevel::NOTICE => OutputInterface::VERBOSITY_VERBOSE,
-        LogLevel::INFO => OutputInterface::VERBOSITY_VERY_VERBOSE,
-        LogLevel::DEBUG => OutputInterface::VERBOSITY_DEBUG,
-        LogLevel::TRACE => OutputInterface::VERBOSITY_DEBUG,
-    );
 
     private $formatLevelMap = array(
         LogLevel::EMERGENCY => 'error',
         LogLevel::ALERT => 'error',
         LogLevel::CRITICAL => 'error',
         LogLevel::ERROR => 'error',
-        LogLevel::WARNING => 'info',
+        LogLevel::WARNING => 'warning',
         LogLevel::DEBUG => 'info',
         LogLevel::INFO => 'info',
         LogLevel::TRACE => 'fg=gray',
@@ -61,9 +50,7 @@ class SymfonyConsoleHandler extends AbstractHandler
                 $shortMessageToSend = $i.'/'.count($splitFullMessage).' '.$message;
             }
 
-            if ($this->outputInterface->getVerbosity() >= $this->verbosityLevelMap[$level]) {
-                $this->outputInterface->writeln(sprintf('<%1$s>[%2$s] %3$s</%1$s>', $this->formatLevelMap[$level], $level, $this->interpolate($shortMessageToSend, $context)));
-            }
+            $this->outputInterface->writeln(sprintf('<%1$s>[%2$s] %3$s</%1$s>', $this->formatLevelMap[$level], $level, $this->interpolate($shortMessageToSend, $context)));
 
             $i++;
         }

--- a/lib/Handler/SymfonyConsoleHandler.php
+++ b/lib/Handler/SymfonyConsoleHandler.php
@@ -17,7 +17,7 @@ class SymfonyConsoleHandler extends AbstractHandler
         LogLevel::ALERT => 'error',
         LogLevel::CRITICAL => 'error',
         LogLevel::ERROR => 'error',
-        LogLevel::WARNING => 'warning',
+        LogLevel::WARNING => 'comment',
         LogLevel::DEBUG => 'info',
         LogLevel::INFO => 'info',
         LogLevel::TRACE => 'fg=gray',


### PR DESCRIPTION
verbosity level checks are already handled in the AbstractHandler->process()